### PR TITLE
Remove set/get/make/swapcontext implementations for arm linux

### DIFF
--- a/src/task/asm.S
+++ b/src/task/asm.S
@@ -34,12 +34,6 @@
 #endif
 #endif
 
-#if defined(__linux__) && defined(__arm__)
-#define NEEDARMCONTEXT 1
-#define SET setmcontext
-#define GET getmcontext
-#endif
-
 #ifdef NEEDX86CONTEXT
 .globl SET
 SET:
@@ -219,48 +213,4 @@ SET:
 
     lwz    r3,    6*4(r3)
     blr
-#endif
-
-#ifdef NEEDARMCONTEXT
-.globl GET
-GET:
-    str    r1, [r0,#4]
-    str    r2, [r0,#8]
-    str    r3, [r0,#12]
-    str    r4, [r0,#16]
-    str    r5, [r0,#20]
-    str    r6, [r0,#24]
-    str    r7, [r0,#28]
-    str    r8, [r0,#32]
-    str    r9, [r0,#36]
-    str    r10, [r0,#40]
-    str    r11, [r0,#44]
-    str    r12, [r0,#48]
-    str    r13, [r0,#52]
-    str    r14, [r0,#56]
-    /* store 1 as r0-to-restore */
-    mov    r1, #1
-    str    r1, [r0]
-    /* return 0 */
-    mov    r0, #0
-    mov    pc, lr
-
-.globl SET
-SET:
-    ldr    r1, [r0,#4]
-    ldr    r2, [r0,#8]
-    ldr    r3, [r0,#12]
-    ldr    r4, [r0,#16]
-    ldr    r5, [r0,#20]
-    ldr    r6, [r0,#24]
-    ldr    r7, [r0,#28]
-    ldr    r8, [r0,#32]
-    ldr    r9, [r0,#36]
-    ldr    r10, [r0,#40]
-    ldr    r11, [r0,#44]
-    ldr    r12, [r0,#48]
-    ldr    r13, [r0,#52]
-    ldr    r14, [r0,#56]
-    ldr    r0, [r0]
-    mov    pc, lr
 #endif

--- a/src/task/context.c
+++ b/src/task/context.c
@@ -30,11 +30,6 @@
 #endif
 #endif
 
-#if defined(__linux__) && defined(__arm__)
-#define NEEDSWAPCONTEXT
-#define NEEDARMMAKECONTEXT
-#endif
-
 #ifdef NEEDPOWERMAKECONTEXT
 void makecontext(ucontext_t *ucp, void (*func)(void), int argc, ...)
 {
@@ -86,26 +81,6 @@ void makecontext(ucontext_t *ucp, void (*func)(void), int argc, ...)
     *--sp = 0;    /* return address */
     ucp->uc_mcontext.mc_rip = (long)func;
     ucp->uc_mcontext.mc_rsp = (long)sp;
-}
-#endif
-
-#ifdef NEEDARMMAKECONTEXT
-void makecontext(ucontext_t *uc, void (*fn)(void), int argc, ...)
-{
-    int i, *sp;
-    va_list arg;
-    
-    sp = (int*)uc->uc_stack.ss_sp+uc->uc_stack.ss_size/4;
-    va_start(arg, argc);
-    
-    if(argc-- > 0) uc->uc_mcontext.arm_r0 = va_arg(arg, uint);
-    if(argc-- > 0) uc->uc_mcontext.arm_r1 = va_arg(arg, uint);
-    if(argc-- > 0) uc->uc_mcontext.arm_r2 = va_arg(arg, uint);
-    if(argc-- > 0) uc->uc_mcontext.arm_r3 = va_arg(arg, uint);
-
-    va_end(arg);
-    uc->uc_mcontext.arm_sp = (uint)sp;
-    uc->uc_mcontext.arm_lr = (uint)fn;
 }
 #endif
 

--- a/src/task/taskimpl.h
+++ b/src/task/taskimpl.h
@@ -104,13 +104,6 @@ extern pid_t rfork_thread(int, void*, int(*)(void*), void*);
 #    include "sparc-ucontext.h"
 #endif
 
-#if defined(__arm__)
-int getmcontext(mcontext_t*);
-void setmcontext(const mcontext_t*);
-#define    setcontext(u)    setmcontext((void *)&((u)->uc_mcontext.arm_r0))
-#define    getcontext(u)    getmcontext((void *)&((u)->uc_mcontext.arm_r0))
-#endif
-
 typedef struct Context Context;
 
 enum


### PR DESCRIPTION
These implemtations are not needed any longer, as arm linux does provide
them in glibc 2.17. Implementations for uClibc are available, as well.

This also fixes zedshaw/mongrel2#232, where mongrel2 on armhf was broken
because these implementations don't support that architecture, but where
enabled because the code only checks for __arm__.